### PR TITLE
Added unit tests for hijack-fd command

### DIFF
--- a/tests/commands/hijack_fd.py
+++ b/tests/commands/hijack_fd.py
@@ -1,18 +1,31 @@
-"""
-`hijack_fd` command test module
-"""
+from tests.remote import RemoteEnumTestGeneric
 
-
-from tests.base import RemoteGefUnitTestGeneric
-
-
-class HijackFdCommand(RemoteGefUnitTestGeneric):
-    """`hijack-fd` command test module"""
-
-
+class HijackFdCommand(RemoteEnumTestGeneric):
+    """Test for the hijack-fd command"""
+    
     cmd = "hijack-fd"
 
+    def test_cmd_run(self):
+        """Test if the hijack-fd command runs without crashing"""
+        gdb = self.target()
+        res = gdb.execute(f"{self.cmd} 1 /dev/null", to_string=True)
+        assert "Success" in res or "Redirected" in res, f"Unexpected output: {res}"
 
-    def test_cmd_hijack_fd(self):
-        gdb = self._gdb
-        res = gdb.execute(f"{self.cmd}", to_string=True)
+    def test_invalid_fd(self):
+        """Test hijack-fd with an invalid file descriptor"""
+        gdb = self.target()
+        res = gdb.execute(f"{self.cmd} 99999 /dev/null", to_string=True)
+        assert "invalid file descriptor" in res or "Error" in res, f"Unexpected output: {res}"
+
+    def test_redirect_stdin(self):
+        """Test hijack-fd redirecting STDIN"""
+        gdb = self.target()
+        res = gdb.execute(f"{self.cmd} 0 localhost:8888", to_string=True)
+        assert "Redirected" in res or "Success" in res, f"Unexpected output: {res}"
+
+    def test_nonexistent_file(self):
+        """Test hijack-fd with a non-existent file"""
+        gdb = self.target()
+        res = gdb.execute(f"{self.cmd} 1 /this/does/not/exist", to_string=True)
+        assert "no such file" in res or "Error" in res, f"Unexpected output: {res}"
+


### PR DESCRIPTION
This PR adds unit tests for the hijack-fd command, as discussed in issue #2621.

What was done?
Added a test to verify that the command executes correctly. Included test cases for:
Redirecting STDOUT to /dev/null.
Handling an invalid file descriptor.
Redirecting STDIN to a network socket.
Using a non-existent file and checking for error handling. Why is this needed?
The hijack-fd command was missing unit tests.
These tests help validate its behavior and prevent regressions. Next steps:
Open to feedback and improvements. Let me know if any modifications are needed. Thanks

## Description

<!-- Describe technically what your patch does. -->

<!-- Why is this change required? What problem does it solve? -->

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
